### PR TITLE
Replace paramVolumeLeft & paramVolumeRight with paramGain in the UI

### DIFF
--- a/{{ cookiecutter.repo_name }}/plugins/{{ cookiecutter.plugin_name }}/{%- if cookiecutter.ui_type != "none" %}UI{{ cookiecutter.plugin_name }}.cpp{%- endif %}
+++ b/{{ cookiecutter.repo_name }}/plugins/{{ cookiecutter.plugin_name }}/{%- if cookiecutter.ui_type != "none" %}UI{{ cookiecutter.plugin_name }}.cpp{%- endif %}
@@ -52,11 +52,8 @@ UI{{ cookiecutter.plugin_name }}::~UI{{ cookiecutter.plugin_name }}() {
 */
 void UI{{ cookiecutter.plugin_name }}::parameterChanged(uint32_t index, float value) {
     switch (index) {
-        case Plugin{{ cookiecutter.plugin_name }}::paramVolumeLeft:
-            // do something when volume_l param is set, such as update a widget
-            break;
-        case Plugin{{ cookiecutter.plugin_name }}::paramVolumeRight:
-            // same for volume_r param
+        case Plugin{{ cookiecutter.plugin_name }}::paramGain:
+            // do something when Gain param is set, such as update a widget
             break;
     }
 


### PR DESCRIPTION
The template for the UI was still using paramVolumeLeft and paramVolumeRight, so it wouldn't compile since commit https://github.com/SpotlightKid/cookiecutter-dpf-effect/commit/dab379902c78f743ad536c6cf5493d1d56846fcc.