### PR TITLE
Don't build both DGL variants

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -15,7 +15,7 @@ submodules:
 
 libs:
 {%- if cookiecutter.ui_type != "none" %}
-	$(MAKE) -C dpf/dgl
+	$(MAKE) -C dpf/dgl {{ "../build/libdgl-cairo.a" if cookiecutter.ui_type == "cairo" else "../build/libdgl-opengl.a" }}
 {%- endif %}
 
 plugins: libs


### PR DESCRIPTION
By default, DGL's Makefile builds both `libdgl-cairo.a` and `libdgl-opengl.a`.

This PR adds a specific target to the Makefile which depends on the UI's type. That way, OpenGL & NanoVG UIs won't have to build `libdgl-cairo.a` and vice versa.