### PR TITLE
Use current year as default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "plugin_uri": "https://{{ cookiecutter.domain }}/plugins/{{ cookiecutter.repo_name }}",
     "project_license": "MIT",
     "version": "0.1.0",
-    "year": "2020",
+    "year": "{% now 'local', '%Y' %}",
     "ui_type": ["opengl", "nanovg", "cairo", "none"],
     "want_midi_input": ["no", "yes"],
     "want_midi_output": ["no", "yes"]


### PR DESCRIPTION
This PR replaces the hard-coded "year" string in cookiecutter.json with a dynamic template which outputs the current year.

This avoids the need to update the variable every year :)